### PR TITLE
DeleteNeRFDatasetOperator and fixing long filepath display

### DIFF
--- a/panels/nerf_3dview_panels/dataset_panel.py
+++ b/panels/nerf_3dview_panels/dataset_panel.py
@@ -1,9 +1,11 @@
 import bpy
+import os
 from turbo_nerf.blender_utility.obj_type_utility import get_active_nerf_obj
 from turbo_nerf.panels.nerf_panel_operators.export_dataset_operator import ExportNeRFDatasetOperator
 from turbo_nerf.panels.nerf_panel_operators.import_dataset_operator import ImportNeRFDatasetOperator
 from turbo_nerf.panels.nerf_panel_operators.unload_nerf_training_data_operator import UnloadNeRFTrainingDataOperator
 from turbo_nerf.utility.nerf_manager import NeRFManager
+from turbo_nerf.panels.nerf_panel_operators.delete_nerf_dataset_operator import DeleteNeRFDatasetOperator
 
 
 class NeRF3DViewDatasetPanelProps(bpy.types.PropertyGroup):
@@ -33,6 +35,7 @@ class NeRF3DViewDatasetPanel(bpy.types.Panel):
         bpy.utils.register_class(ImportNeRFDatasetOperator)
         bpy.utils.register_class(ExportNeRFDatasetOperator)
         bpy.utils.register_class(UnloadNeRFTrainingDataOperator)
+        bpy.utils.register_class(DeleteNeRFDatasetOperator)
         bpy.utils.register_class(NeRF3DViewDatasetPanelProps)
         bpy.types.Scene.nerf_dataset_panel_props = bpy.props.PointerProperty(type=NeRF3DViewDatasetPanelProps)
     
@@ -43,6 +46,7 @@ class NeRF3DViewDatasetPanel(bpy.types.Panel):
         bpy.utils.unregister_class(ImportNeRFDatasetOperator)
         bpy.utils.unregister_class(ExportNeRFDatasetOperator)
         bpy.utils.unregister_class(UnloadNeRFTrainingDataOperator)
+        bpy.utils.unregister_class(DeleteNeRFDatasetOperator)
         bpy.utils.unregister_class(NeRF3DViewDatasetPanelProps)
         del bpy.types.Scene.nerf_dataset_panel_props
 
@@ -66,6 +70,12 @@ class NeRF3DViewDatasetPanel(bpy.types.Panel):
             nerf = NeRFManager.get_nerf_for_obj(nerf_obj)
             
             if nerf.dataset is not None:
+                dataset_path = nerf.dataset.file_path
+                parent_folder = os.path.basename(os.path.dirname(dataset_path))
+                file_name = os.path.basename(dataset_path)
+
                 row = box.row()
-                row.label(text=f"{nerf.dataset.file_path}")
+                row.label(text=f"{parent_folder}\{file_name}")
+
+                row.operator(DeleteNeRFDatasetOperator.bl_idname, icon='X', text="")
 

--- a/panels/nerf_3dview_panels/dataset_panel.py
+++ b/panels/nerf_3dview_panels/dataset_panel.py
@@ -71,8 +71,8 @@ class NeRF3DViewDatasetPanel(bpy.types.Panel):
             
             if nerf.dataset is not None:
                 dataset_path = nerf.dataset.file_path
-                parent_folder = os.path.basename(os.path.dirname(dataset_path))
-                file_name = os.path.basename(dataset_path)
+                parent_folder = Path(dataset_path).parent.name
+                file_name = dataset_path.name
 
                 row = box.row()
                 row.label(text=f"{parent_folder}\{file_name}")

--- a/panels/nerf_3dview_panels/dataset_panel.py
+++ b/panels/nerf_3dview_panels/dataset_panel.py
@@ -1,5 +1,5 @@
 import bpy
-import os
+from pathlib import Path
 from turbo_nerf.blender_utility.obj_type_utility import get_active_nerf_obj
 from turbo_nerf.panels.nerf_panel_operators.export_dataset_operator import ExportNeRFDatasetOperator
 from turbo_nerf.panels.nerf_panel_operators.import_dataset_operator import ImportNeRFDatasetOperator

--- a/panels/nerf_panel_operators/delete_nerf_dataset_operator.py
+++ b/panels/nerf_panel_operators/delete_nerf_dataset_operator.py
@@ -24,10 +24,6 @@ class DeleteNeRFDatasetOperator(bpy.types.Operator):
         
         if NeRFManager.is_image_data_loaded(nerf_obj):
             NeRFManager.unload_training_images(nerf_obj)
-            print("Unloaded Images")
-            
-        else: 
-            print("No Images to Unload.")
 
         delete_object(nerf_obj)
 

--- a/panels/nerf_panel_operators/delete_nerf_dataset_operator.py
+++ b/panels/nerf_panel_operators/delete_nerf_dataset_operator.py
@@ -1,0 +1,44 @@
+import bpy
+from turbo_nerf.blender_utility.obj_type_utility import get_active_nerf_obj
+from turbo_nerf.blender_utility.object_utility import delete_object
+from turbo_nerf.utility.nerf_manager import NeRFManager
+
+
+class DeleteNeRFDatasetOperator(bpy.types.Operator):
+    bl_label = "Delete NeRF Dataset"
+    bl_idname = "turbo_nerf.delete_nerf_dataset_operator"
+    bl_description = "Are you sure you want to delete?"
+    bl_options = {'INTERNAL'}
+
+    object_name: bpy.props.StringProperty()
+
+    @classmethod
+    def poll(cls, context):
+        nerf_obj = get_active_nerf_obj(context)
+        return nerf_obj is not None
+        
+    
+    def execute(self, context):
+    
+        nerf_obj = get_active_nerf_obj(context)
+        
+        if NeRFManager.is_image_data_loaded(nerf_obj):
+            NeRFManager.unload_training_images(nerf_obj)
+            print("Unloaded Images")
+            
+        else: 
+            print("No Images to Unload.")
+
+        delete_object(nerf_obj)
+
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context):
+        self.layout.label(text="Are you sure you want to delete? This can't be undone.")
+
+
+        
+

--- a/panels/nerf_panel_operators/delete_nerf_dataset_operator.py
+++ b/panels/nerf_panel_operators/delete_nerf_dataset_operator.py
@@ -39,6 +39,3 @@ class DeleteNeRFDatasetOperator(bpy.types.Operator):
     def draw(self, context):
         self.layout.label(text="Are you sure you want to delete? This can't be undone.")
 
-
-        
-


### PR DESCRIPTION
These commits were what I implemented to make and use the new DeleteNeRFDatasetOperator. Allowing people to fully unload the dataset and delete the whole hierarchy at the push of _two_ buttons. Also, I tested for the fact that if i have images loaded in from one nerf, fully delete it, and import another it doesn't add onto the original data meaning the unloading of datasets works properly. Let me know if there's anything you want to add too! Pleasure working with ya and excited to keep doing so :)


- Colin K